### PR TITLE
Added compatibility for team projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,31 +7,41 @@ A VS Code extension for Vercel deployment status.
 ## Usage
 
 1. Install the extension from the [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=haydenbleasel.vercel-vscode) or with the terminal command `code --install-extension haydenbleasel.vercel-vscode`.
-2. Open the extension settings and enter your API token.
-3. Add your Vercel Project ID to your workspace. This can be done in one of two ways (see below).
+2. Open the extension settings and enter your API token (recommended to put this in your user settings so it is not shared with others).
+3. Add your Vercel Project ID and/or Team ID to your workspace. This can be done in one of two ways (see below).
 4. Reload VSCode to apply the changes and start using the extension.
 
-## Vercel Project ID
+## Settings Properties
 
-Your Vercel Project ID can be found in the Vercel dashboard under `Settings > General > Project ID` and can be added to the workspace in one of two ways:
+### Vercel Project ID
 
-### Using the Vercel `project.json`
+Your Vercel Project ID can be found in the Vercel dashboard under `Settings > General > Project ID`.
 
-The [`vercel.json`](https://vercel.com/docs/project-configuration) configuration file lets you configure, and override the default behavior of Vercel from within your project. You can add your Vercel Project ID to this file by adding the following:
+### (Optional) Vercel Team ID
+
+If you are working on a project that is part of a team, you will also need your team ID to access the API. Your Vercel Team ID can be found in the Vercel dashboard under `{TEAM} > Settings > General > Team ID`.
+
+## Configuration
+
+#### Using VSCode settings (Recommended)
+
+You can create a `.vscode/settings.json` file in your project and add the following:
 
 ```json
 {
-  "projectId": "prj_myprojectID"
+  "vercel-vscode.projectId": "prj_myProjectID",
+  "vercel-vscode.teamId":: "team_myTeamID"
 }
 ```
 
-### Using VSCode settings
+### Using .vercel/project.json
 
-Alternatively, you can create a `.vscode/settings.json` file in your project and add the following:
+You can add your Vercel Project ID and/or Team Id to this file by adding the following:
 
 ```json
 {
-  "vercel-vscode.project": "prj_myprojectID"
+  "projectId": "prj_myProjectID",
+  "teamId": "team_myTeamID"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can create a `.vscode/settings.json` file in your project and add the follow
 ```json
 {
   "vercel-vscode.projectId": "prj_myProjectID",
-  "vercel-vscode.teamId":: "team_myTeamID"
+  "vercel-vscode.teamId": "team_myTeamID"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -30,15 +30,20 @@
     "configuration": {
       "title": "Vercel",
       "properties": {
-        "vercel-vscode.access_token": {
+        "vercelVSCode.accessToken": {
           "type": "string",
           "default": "",
-          "description": "Your Vercel access token"
+          "description": "Your Vercel Access Token"
         },
-        "vercel-vscode.project": {
+        "vercelVSCode.projectId": {
           "type": "string",
           "default": "",
-          "description": "Your Vercel project ID"
+          "description": "Your Vercel Project ID"
+        },
+        "vercelVSCode.teamId": {
+          "type": "string",
+          "default": "",
+          "description": "Your Vercel Team ID"
         }
       }
     },
@@ -76,5 +81,8 @@
     "typescript": "^5.0.3"
   },
   "prettier": "@beskar-labs/harmony/prettier",
-  "author": "Hayden Bleasel <hello@haydenbleasel.com>"
+  "author": "Hayden Bleasel <hello@haydenbleasel.com>",
+  "contributors": [
+    "Anna Zhang <annazhang343@gmail.com>"
+  ]
 }

--- a/src/utils/fetchDeployments.ts
+++ b/src/utils/fetchDeployments.ts
@@ -17,15 +17,18 @@ type VercelResponse = {
 };
 
 const fetchDeployments = async (
-  project: string,
-  access_token: string
+  accessToken: string,
+  projectId: string,
+  teamId?: string
 ): Promise<VercelResponse['deployments']> => {
   const response = await fetch(
-    `https://api.vercel.com/v6/deployments?projectId=${project}&limit=1`,
+    teamId
+      ? `https://api.vercel.com/v6/deployments?teamId=${teamId}&projectId=${projectId}&limit=1`
+      : `https://api.vercel.com/v6/deployments?projectId=${projectId}&limit=1`,
     {
       method: 'GET',
       headers: {
-        Authorization: `Bearer ${access_token}`,
+        Authorization: `Bearer ${accessToken}`,
       },
     }
   );

--- a/src/utils/parseJson.ts
+++ b/src/utils/parseJson.ts
@@ -1,7 +1,14 @@
 import { workspace, window, Uri } from 'vscode';
 import parseError from '@/utils/parseError';
 
-const getProjectIdFromJson = async (): Promise<string | undefined> => {
+export type VercelProjectJson = {
+  projectId?: string;
+  teamId?: string;
+};
+
+const getProjectIdFromJson = async (): Promise<
+  VercelProjectJson | undefined
+> => {
   if (!workspace.workspaceFolders?.[0]) {
     return undefined;
   }
@@ -20,10 +27,10 @@ const getProjectIdFromJson = async (): Promise<string | undefined> => {
 
   try {
     const stringJson: string = Buffer.from(vercelProjectJson).toString('utf8');
-    const parsedVercelJSON: { projectId?: string } = JSON.parse(stringJson) as {
-      projectId?: string;
-    };
-    return parsedVercelJSON.projectId;
+    const parsedVercelProjectJSON: { projectId?: string } = JSON.parse(
+      stringJson
+    ) as VercelProjectJson;
+    return parsedVercelProjectJSON;
   } catch (error) {
     const message = parseError(error);
     await window.showErrorMessage(message);

--- a/src/utils/updateStatus.ts
+++ b/src/utils/updateStatus.ts
@@ -7,15 +7,17 @@ import toSentenceCase from '@/utils/sentenceCase';
 
 const updateStatus = async ({
   statusBarItem,
-  project,
-  access_token,
+  accessToken,
+  projectId,
+  teamId,
 }: {
   statusBarItem: StatusBarItem;
-  project: string;
-  access_token: string;
+  accessToken: string;
+  projectId: string;
+  teamId?: string;
 }): Promise<void> => {
   try {
-    const deployments = await fetchDeployments(project, access_token);
+    const deployments = await fetchDeployments(accessToken, projectId, teamId);
 
     if (!deployments?.length) {
       return;


### PR DESCRIPTION
Added ability to use team projects by adding an optional `teamId` property to `settings.json` or `project.json`. 

Changes:
- Added `teamId` as an optional parsable property for both config sources
- Added new API call for when `teamId` is present in configuration
- Cleaned up variable naming to use camel casing as recommended by VSCode
- Updated README.md to reflect the changes